### PR TITLE
Color tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,40 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
+  <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Astoria Digital Pattern Library</title>
     <link rel="stylesheet" href="style.css">
     <link
-        href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap"
-        rel="stylesheet">
+      href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap"
+      rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Fjalla+One&display=swap" rel="stylesheet">
-</head>
+  </head>
 
-
-
-<body>
+  <body>
 
     <header>
-
-        <h1>Astoria Digital Pattern Library</h1>
-
+      <h1>Astoria Digital Pattern Library</h1>
     </header>
 
-
     <nav>
-        <ul>
-            <li><a href="#typography">Typography</a></li>
-            <li><a href="#links">Links &amp Buttons</a></li>
-            <li><a href="#layout">Layout</a></li>
-        </ul>
+      <ul>
+        <li><a href="#">Typography</a></li>
+        <li><a href="#">Links &amp Buttons</a></li>
+        <li><a href="#">Layout</a></li>
+      </ul>
     </nav>
 
+    <main>
 
-
-    <section id="typography">
+      <section>
         <h2># Headings</h2>
 
         <h1>h1. Digital volunteers for the community</h1>
@@ -43,16 +38,16 @@
         <h4>h4. Digital volunteers for the community</h4>
         <h5>h5. Digital volunteers for the community</h5>
         <h6>h6. Digital volunteers for the community</h6>
-    </section>
+      </section>
 
-    <section>
+      <section>
         <h2># Paragraphs</h2>
         <p>This project was created to support existing Freedom of Information Law resources by representing the FOIL Request process in New York State and providing resources to submit a request. Please <a href="mailto:ania@astoria.digital">reach out to us</a> if you have any questions or suggestions.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Massa massa ultricies mi quis hendrerit dolor magna.</p>
-    </section>
+      </section>
 
-    <section id="links">
+      <section>
         <h2># Links &amp Buttons</h2>
 
         <p><a href="#">This is a link</a></p>
@@ -60,27 +55,24 @@
         <button>Button</button>
 
         <button disabled>Disabled</button>
-    </section>
+      </section>
 
-    <section id="layout">
+      <section>
         <h2># Layout</h2>
 
         <section class="card">
-            <h2 class="card__header">Freedom of Information Law Requests</h2>
-            <p class="card__paragraph">This project was created to support existing Freedom of Information Law resources by
-                representing the FOIL Request process in New York State and providing resources to submit a request.</p>
-            <p class="card__secondary-paragraph">Please reach out to us if you have any questions or suggestions.</p>
+          <h2 class="card__header">Freedom of Information Law Requests</h2>
+          <p class="card__paragraph">This project was created to support existing Freedom of Information Law resources by
+            representing the FOIL Request process in New York State and providing resources to submit a request.</p>
+          <p class="card__secondary-paragraph">Please reach out to us if you have any questions or suggestions.</p>
         </section>
-    </section>
+      </section>
+
+    </main>
 
     <footer>
-
-        <p class="copyright"><small><a href="https://astoria.digital/">© Astoria Digital 2020</a></small></p>
-
+      <p class="copyright"><small><a href="https://astoria.digital/">© Astoria Digital 2020</a></small></p>
     </footer>
 
-</body>
-
-
-
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,8 +1,43 @@
+/* Variables */
+
+:root {
+  --ad-primary-color: #ffda00;
+  --ad-main-text: #000;
+  --ad-background-color: #fff;
+}
+
+@media screen and (prefers-color-scheme: dark) {
+  :root {
+    --ad-background-color: #000;
+    --ad-main-text: #fff;
+  }
+}
+
+/* Layout */
+
+* {
+  box-sizing: border-box;
+  /* width and height includes padding and border */
+}
+
+main {
+  max-width: 65ch;
+  margin: 0 auto;
+  padding: 0 1em;
+}
+
+section {
+  margin: 1em 0;
+}
+
 /* Typography */
 
 html {
   font-size: 18px;
   font-family: 'DM Mono', Courier, monospace;
+  line-height: 1.25;
+  background-color: var(--ad-background-color);
+  color: var(--ad-main-text);
 }
 
 @media screen and (min-width: 700px) {
@@ -12,22 +47,18 @@ html {
 }
 
 body {
-  margin: 0 auto;
-  padding: 1em;
+  margin: 0;
 }
 
 h1, h2, h3 {
   font-family: 'Fjalla One', Helvetica, sans-serif;
   text-transform: uppercase;
   font-weight: 400;
-  line-height: 1.25;
-
 }
 
 h4, h5, h6 {
   font-family: 'DM Mono', Courier, monospace;
   font-weight: 300;
-  line-height: 1.25;
 }
 
 h1 {
@@ -54,15 +85,11 @@ h6 {
   font-size: 1.25em;
 }
 
-a, p {
-  line-height: 1.5;
-}
-
-.copyright {
-  text-align: center;
-}
-
 /* Navigation */
+
+ol, ul {
+  line-height: 2;
+}
 
 ul {
   list-style-type: '- ';
@@ -70,38 +97,17 @@ ul {
 
 /* Links */
 
-a {
-  text-decoration: underline 0.1em solid;
-  color: black;
-}
-
-a:link {
-  text-decoration: underline 0.1em solid;
-  color: black;
-}
-
+a:link,
+a:active,
 a:visited {
-  text-decoration: none;
-  color: black;
-  background-color: #FFDA00;
-}
-
-a:focus {
-  text-decoration: none;
-  color: black;
-  background-color: #FFDA00;
+  text-decoration: underline 0.1em solid;
+  color: var(--ad-main-text);
 }
 
 a:hover {
   text-decoration: none;
-  color: black;
-  background-color: #FFDA00;
-}
-
-a:active {
-  text-decoration: none;
-  color: black;
-  background-color: #FFDA00;
+  color: #000;
+  background-color: var(--ad-primary-color);
 }
 
 /* Buttons */
@@ -109,9 +115,8 @@ a:active {
 button {
   font-family: inherit;
   font-size: 100%;
-  line-height: 1.15;
-  background: white;
-  margin: 0;
+  background-color: var(--ad-background-color);
+  color: var(--ad-main-text);
   overflow: visible;
   text-transform: none;
   -webkit-appearance: button;
@@ -119,32 +124,23 @@ button {
   margin: 0.5em;
   cursor: pointer;
   border-radius: 0.15rem;
-  border: 2px solid;
+  border: 0.1em solid;
 }
 
 button:hover {
-  background: #FFDA00;
-}
-
-button:focus {
-  background: #FFDA00;
+  background-color: var(--ad-primary-color);
+  color: #000;
+  border-color: #fff;
 }
 
 button[disabled] {
-  opacity: 0.85;
-  pointer-events: none;
+  opacity: 0.7;
+  background-color: var(--ad-background-color);
 }
 
-
-/* Layout */
-
-* {
-  box-sizing: border-box;
-  /* width and height includes padding and border */
-}
-
-section {
-  margin: 1em 0;
+button[disabled]:hover {
+  color: var(--ad-main-text);
+  cursor: not-allowed;
 }
 
 /* Cards */
@@ -154,35 +150,46 @@ section {
 }
 
 .card__header {
-  padding-left: 1em;
-  padding-right: 1em;
+  padding: 0 1em;
+}
+
+.card__paragraph,
+.card__secondary-paragraph {
+  padding: 1em 2em 0 2em;
 }
 
 .card__paragraph {
   border-top: 0.15em solid;
-  padding-top: 1em;
-  padding-left: 2em;
-  padding-right: 2em;
 }
 
 .card__secondary-paragraph {
   border-top: 0.15em dashed;
-  padding-top: 1em;
-  padding-left: 2em;
-  padding-right: 2em;
 }
 
 /* Header */
 
-header {
+body > header {
   text-align: center;
-  background-color: #FFDA00;
+  background-color: var(--ad-primary-color);
+  color: #000;
   padding: 1em;
 }
 
 /* Footer */
 
 footer {
-  padding-top: 2em;
-  padding-bottom: 1em;
+  padding: 2em 0;
+  color: #000;
+  background-color: var(--ad-primary-color);
+}
+
+footer a:link,
+footer a:visited,
+footer a:active {
+  color: #000;
+}
+
+footer small,
+.copyright {
+  text-align: center;
 }


### PR DESCRIPTION
Use CSS variables to define colors. This way, implementing sites can
override the variable once, and change the theme color for every
implementation piece, aka changing yellow to green for muckrock. This
also allows easier support for dark mode, which I also implemented.

Use 2 spaces for HTML indentation, and remove some blank lines.

Consolidate more properties to use short hand and shift some groupings
for easier readability.

Remove the body padding. Our designs usually go full width, so we want
to support that. Instead, style the `main` tag with that padding, along
with a max width of 65 wide characters, around the usability design
recommended/researched reading ideal.

Consolidate line heights and let the cascade take care of most of them.
Add extra line height to lists to match designs.

Increase disabled fade effect to make more prominent, and add the
disabled cursor on hover instead of removing all events, to give the
user feedback.