### PR TITLE
Fix table zebra striping colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,12 +4,14 @@
   --ad-primary-color: #ffda00;
   --ad-main-text: #000;
   --ad-background-color: #fff;
+  --ad-background-accent-color: #eee;
 }
 
 @media screen and (prefers-color-scheme: dark) {
   :root {
-    --ad-background-color: #000;
     --ad-main-text: #fff;
+    --ad-background-color: #000;
+    --ad-background-accent-color: #eeeeee29;
   }
 }
 
@@ -167,7 +169,7 @@ th:last-of-type, td:last-of-type {
 }
 
 tr:nth-child(even) {
-  background-color: #eee;
+  background-color: var(--ad-background-accent-color);
 }
 
 /* Cards */


### PR DESCRIPTION
The zebra stripe color is hard coded, not a variable, which means it
doesn't adapt properly between light and dark themes.